### PR TITLE
fix: add contents write permission to publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,7 +12,7 @@ concurrency:
 
 permissions:
   id-token: write  # Required for OIDC
-  contents: read
+  contents: write  # Required to create releases and push tags
 
 jobs:
   release:


### PR DESCRIPTION
## Summary
- Fixes the publish workflow failure by adding `contents: write` permission
- The semantic-release step was failing with "Permission denied" when trying to push tags and create releases

## Changes
- Updated `.github/workflows/publish.yaml` to include `contents: write` permission alongside the existing `id-token: write`

## Test plan
- [ ] Merge this PR
- [ ] Trigger the publish workflow by pushing to main branch
- [ ] Verify that semantic-release can successfully create tags and releases

🤖 Generated with [Claude Code](https://claude.ai/code)