### PR TITLE
fix: sync version from semantic-release to dist package.json

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -52,9 +52,17 @@ jobs:
           HUSKY: 0
       - name: Publish to npm with Trusted Publishing
         run: |
-          # Create tarball for GitHub release assets
+          # Get the version from the main package.json (updated by semantic-release)
+          VERSION=$(node -p "require('./package.json').version")
+          echo "Publishing version: $VERSION"
+
+          # Update the version in dist/package.json
           cd dist
+          npm version $VERSION --no-git-tag-version
+
+          # Create tarball for GitHub release assets
           npm pack
+
           # Publish to npm with provenance using trusted publishing
           npm publish --provenance --access public
         env:


### PR DESCRIPTION
Since we removed @semantic-release/npm plugin, we need to manually
sync the version that semantic-release calculates in the root package.json
to the dist/package.json before publishing to npm.

- Extract version from root package.json (updated by semantic-release)
- Update dist/package.json version using npm version command
- Ensures published package has correct semantic version

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
